### PR TITLE
adding ability to give pytest flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ mayatest -m 2017
 mayatest -m 2017 --pytest="test_sometest.py"
 # to only run test_func
 mayatest -m 2017 --pytest="test_sometest.py::test_func"
+# to get verbose results, you can include pytest flags
+mayatest -m 2017 --pytest="-vvv test_sometest.py"
 ```
 
 For more information using pytest go to their [docs](https://docs.pytest.org/en/latest/usage.html).

--- a/mayatest/runner.py
+++ b/mayatest/runner.py
@@ -4,6 +4,7 @@ python site-packages
 """
 import os
 import sys
+import shlex
 
 try:
     import pytest
@@ -40,8 +41,8 @@ class PytestMayaPlugin(object):
 
 
 def main():
-    pytest_args = sys.argv[2]
-    pytest.main([pytest_args], plugins=[PytestMayaPlugin()])
+    pytest_args = shlex.split(sys.argv[2])
+    pytest.main(pytest_args, plugins=[PytestMayaPlugin()])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I wanted to get the same per-function progress results from pytest by using -vvv, but the previous code was only accepting the first argument given in the --pytest="xxx" argument.  adding in the shlex split allows us to give more than just 1 option when we send to the main command --pytest="-vvv <filename>"

thanks!